### PR TITLE
db, reft : Payment Entity에서 구매내역 String으로 저장하도록 수정 [#38]

### DIFF
--- a/src/main/java/dev/muin/backend/domain/Payment/Payment.java
+++ b/src/main/java/dev/muin/backend/domain/Payment/Payment.java
@@ -1,6 +1,6 @@
 package dev.muin.backend.domain.Payment;
 
-import dev.muin.backend.domain.Stock.Stock;
+import dev.muin.backend.domain.Store.Store;
 import dev.muin.backend.domain.User.User;
 import lombok.Getter;
 
@@ -12,20 +12,20 @@ import java.time.LocalDateTime;
 public class Payment {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name="payment_id")
+    @Column(name = "payment_id")
     private short id;
 
-    private short quantity;
-
+    /**
+     * contains stock's {name, quantity, each price}, total price
+     */
+    private String buyList;
     private LocalDateTime payTime;
 
-    private int price;
-
     @ManyToOne
-    @JoinColumn(name="user_id")
+    @JoinColumn(name = "user_id")
     private User user;
 
     @ManyToOne
-    @JoinColumn(name="stock_id")
-    private Stock stock;
+    @JoinColumn(name = "store_id")
+    private Store store;
 }

--- a/src/main/java/dev/muin/backend/domain/Stock/Stock.java
+++ b/src/main/java/dev/muin/backend/domain/Stock/Stock.java
@@ -1,12 +1,10 @@
 package dev.muin.backend.domain.Stock;
 
-import dev.muin.backend.domain.Payment.Payment;
 import dev.muin.backend.domain.Product.Product;
 import dev.muin.backend.domain.Store.Store;
 import lombok.Getter;
 
 import javax.persistence.*;
-import java.util.List;
 
 @Getter
 @Entity
@@ -14,16 +12,13 @@ public class Stock {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private short id;
-    private short quantity;
+    private int quantity;
 
     @ManyToOne
-    @JoinColumn(name="store_id")
+    @JoinColumn(name = "store_id")
     private Store store;
 
-    @OneToMany(mappedBy = "stock")
-    private List<Payment> payments;
-
     @ManyToOne
-    @JoinColumn(name="product_id")
+    @JoinColumn(name = "product_id")
     private Product product;
 }

--- a/src/main/java/dev/muin/backend/domain/Store/Store.java
+++ b/src/main/java/dev/muin/backend/domain/Store/Store.java
@@ -1,5 +1,6 @@
 package dev.muin.backend.domain.Store;
 
+import dev.muin.backend.domain.Payment.Payment;
 import dev.muin.backend.domain.Sales.Sales;
 import dev.muin.backend.domain.Stock.Stock;
 import dev.muin.backend.domain.User.User;
@@ -46,6 +47,9 @@ public class Store {
 
     @OneToMany(mappedBy = "store")
     private List<Stock> stocks;
+
+    @OneToMany(mappedBy = "store")
+    private List<Payment> payments;
 
     public void updateUser(@NonNull User user) {
         this.user = user;


### PR DESCRIPTION
- Payment Entity에서 구매내역 String으로 저장하도록 수정
- 공백 수정

Resolved #38