### PR TITLE
feat : LocalDateTime 에 시차 반영, 테스트용 매장 데이터 추가 [#86]

### DIFF
--- a/src/main/java/dev/muin/backend/web/request/PaymentRequest.java
+++ b/src/main/java/dev/muin/backend/web/request/PaymentRequest.java
@@ -8,6 +8,8 @@ import lombok.Setter;
 import lombok.ToString;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.List;
 
 
@@ -19,11 +21,14 @@ public class PaymentRequest {
     private List<PaymentBuyListDto> stocks;
     private Integer totalPrice;
 
+    /**
+     * payTime: Because Herorku server is located at USA, fixed ZonedDateTime to sync timezone
+     */
     public Payment toEntity(Store store) {
         return Payment.builder()
                 .buyList(new Gson().toJson(stocks))
                 .totalPrice(totalPrice)
-                .payTime(LocalDateTime.now())
+                .payTime(LocalDateTime.ofInstant(ZonedDateTime.now().toInstant(), ZoneId.of("Asia/Seoul")))
                 .store(store)
                 .build();
     }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -66,12 +66,10 @@ values (1, 'SNACK'),
        (9, 'RAMEN');
 -- stock
 insert into stock(quantity, store_id, product_id)
-values (0, 1, 0),
-       (5, 1, 22),
-       (10, 1, 44),
-       (11, 1, 88),
-       (9, 1, 122),
-       (100, 2, 144),
+select 9999, 1, product_id FROM product;
+
+insert into stock(quantity, store_id, product_id)
+values (100, 2, 144),
        (100, 2, 166),
        (100, 2, 177),
        (100, 3, 1),


### PR DESCRIPTION
- LocalDateTime 에 시차 반영하기
- 테스트용 매장 데이터 추가(모든 재고 9999개)

Resolves #86